### PR TITLE
Able to specify size and fps params

### DIFF
--- a/lib/bebop.js
+++ b/lib/bebop.js
@@ -220,6 +220,8 @@ Bebop.prototype.getVideoStream = function() {
 
 Bebop.prototype.getMjpegStream = function(opts) {
   opts = opts || {};
+  opts.size = opts.size || "640x368";
+  opts.fps = opts.fps || 30;
   opts.quality = opts.quality || "1";
 
   var stream = through(function write(data) {
@@ -228,8 +230,8 @@ Bebop.prototype.getMjpegStream = function(opts) {
 
   ffmpeg(this.getVideoStream())
     .toFormat("mjpeg")
-    .size("640x368")
-    .inputFPS(30)
+    .size(opts.size)
+    .inputFPS(opts.fps)
     .outputOptions(["-qscale:v " + opts.quality])
     .writeToStream(stream);
 


### PR DESCRIPTION
Abst
------

The opts variable has to have a size and fps values in a getMjpegStream method of bebop.js

How to use
--------------

You can use it following as (e.g. in node-bebop/examples/opencv-face-tracking.js ) 

```
var drone = bebop.createClient(),
    opts = {'size': '320x240', 'fps': 24, 'quality': 1},
    mjpg = drone.getMjpegStream(opts),
    w = new cv.NamedWindow("Video", 0),
    buf = null;
```