### PR TITLE
Don't add face.x and face.y to draw a rectangle

### DIFF
--- a/examples/opencv-face-tracking.js
+++ b/examples/opencv-face-tracking.js
@@ -41,7 +41,7 @@ async.forever(
           for (var i = 0; i < faces.length; i++) {
             var face = faces[i];
             im.rectangle([face.x, face.y],
-              [face.x + face.width, face.y + face.height], [0, 255, 0], 2);
+              [face.width, face.height], [0, 255, 0], 2);
           }
 
           w.show(im);


### PR DESCRIPTION
Abst
------

I found a bit bug in an example of detecting a face.
Currently, when a face is detected , the large square would draw.