### PR TITLE
Catch and emit connection errors from the bebop module

### DIFF
--- a/lib/bebop.js
+++ b/lib/bebop.js
@@ -262,6 +262,9 @@ Bebop.prototype.connect = function(callback) {
 };
 
 Bebop.prototype.discover = function(callback) {
+  this._discoveryClient.on("error", function(error) {
+    this.emit("error", error);
+  }.bind(this));
   this._discoveryClient.connect(this.discoveryPort, this.ip, function() {
     this._discoveryClient.write(JSON.stringify({
       "controller_type": "computer",


### PR DESCRIPTION
Prevents the lib from crashing the node script if there is an error while connecting