### PR TITLE
Feature/firmware 4.0

### DIFF
--- a/lib/bebop.js
+++ b/lib/bebop.js
@@ -300,9 +300,15 @@ Bebop.prototype._packetReceiver = function(message) {
   if (networkFrame.id === constants.BD_NET_DC_EVENT_ID ||
       networkFrame.id === constants.BD_NET_DC_NAVDATA_ID) {
 
-    var commandProject = networkFrame.data.readUInt8(0),
+    var commandProject = 0,
+      commandClass = 0,
+      commandId = 0;
+
+    if(networkFrame.data != null) {
+      commandProject = networkFrame.data.readUInt8(0),
         commandClass = networkFrame.data.readUInt8(1),
         commandId = networkFrame.data.readUInt16LE(2);
+    }
 
     var offset = 4;
     var args = {};


### PR DESCRIPTION
Implemented a solution to the following error 

```
Cannot read property 'readUInt8' of undefined at Bebop._packetReceiver 
```
when connecting to a Bebop 2 drone with firmware newer than 4.0.
This code has been successfully tested on Bebop 2 drone with latest firmware available now.